### PR TITLE
Plugin work again after the update

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -103,7 +103,7 @@ def DisplayGroupChannels(name):
 
 ####################################################################################################
 @route("/video/vdr/LiveTVMenu")
-def LiveTVMenu(sender, channel, thumb, include_oc=False):
+def LiveTVMenu(sender, channel, thumb, include_oc=False, checkFiles = 0, includeBandwidths = 0):
 
 	stream = STREAM_URL % (Prefs['host'], Prefs['port'], Prefs['stream'],channel)
 	Log.Info("testAlex, Open the following Stream: %s", stream)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -106,6 +106,7 @@ def DisplayGroupChannels(name):
 def LiveTVMenu(sender, channel, thumb, include_oc=False):
 
 	stream = STREAM_URL % (Prefs['host'], Prefs['port'], Prefs['stream'],channel)
+	Log.Info("testAlex, Open the following Stream: %s", stream)
 	Log("Stream reached ======")
 
 	if (thumb == "true"):

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -178,7 +178,7 @@ def LiveTVMenu(sender, channel, thumb, include_oc=False):
 		)
 
 	if include_oc:
-		Log.Info("includoc true: %s", objects=[video])
+		Log.Info("includoc true: %s", video)
 		return ObjectContainer(objects=[video])
 	Log.Info("includeoc false: %s", video)
 	return video

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -103,7 +103,7 @@ def DisplayGroupChannels(name):
 
 ####################################################################################################
 @route("/video/vdr/LiveTVMenu")
-def LiveTVMenu(sender, channel, thumb, include_oc=False, checkFiles = 0, includeBandwidths = 0):
+def LiveTVMenu(sender, channel, thumb, include_oc=False, checkFiles = 0, includeBandwidths = 0, includeExtras = 0, offset = 0):
 
 	stream = STREAM_URL % (Prefs['host'], Prefs['port'], Prefs['stream'],channel)
 	Log.Info("testAlex, Open the following Stream: %s", stream)

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -106,7 +106,6 @@ def DisplayGroupChannels(name):
 def LiveTVMenu(sender, channel, thumb, include_oc=False, checkFiles = 0, includeBandwidths = 0, includeExtras = 0, offset = 0):
 
 	stream = STREAM_URL % (Prefs['host'], Prefs['port'], Prefs['stream'],channel)
-	Log.Info("testAlex, Open the following Stream: %s", stream)
 	Log("Stream reached ======")
 
 	if (thumb == "true"):
@@ -178,7 +177,5 @@ def LiveTVMenu(sender, channel, thumb, include_oc=False, checkFiles = 0, include
 		)
 
 	if include_oc:
-		Log.Info("includoc true: %s", video)
 		return ObjectContainer(objects=[video])
-	Log.Info("includeoc false: %s", video)
 	return video

--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -178,6 +178,7 @@ def LiveTVMenu(sender, channel, thumb, include_oc=False):
 		)
 
 	if include_oc:
+		Log.Info("includoc true: %s", objects=[video])
 		return ObjectContainer(objects=[video])
-
+	Log.Info("includeoc false: %s", video)
 	return video


### PR DESCRIPTION
Hi, i do not have experience in developing plugins for plex. I used your plugin month ago and after some updates it does not work any more. I spend some time to have a look into the log and found some error messages. I fixed them by adding the new parameter to the LiveTVMenu method. I currently do not know something about that parameter, but currently the plugin works with VDR 2.2 on my ubuntu VDR.

Currently there is a problem with the conversion of the stream. I will spend some time there, but currently have no idea why it does not work.

Cheers
bigblue